### PR TITLE
Extend privileges

### DIFF
--- a/client.go
+++ b/client.go
@@ -29,6 +29,7 @@ type Client interface {
 	BlobstoreRead(string) (*Blobstore, error)
 	BlobstoreUpdate(string, Blobstore) error
 	BlobstoreDelete(string) error
+	Privileges() ([]Privilege, error)
 	PrivilegeCreate(Privilege) error
 	PrivilegeRead(string) (*Privilege, error)
 	PrivilegeUpdate(string, Privilege) error

--- a/privilege.go
+++ b/privilege.go
@@ -11,14 +11,32 @@ const (
 	privilegeAPIEndpoint = "service/rest/beta/security/privileges"
 
 	// PrivilegeDomains
-	PrivilegeDomainAPIKey       = "apikey"
-	PrivilegeDomainAnalytics    = "analytics"
-	PrivilegeDomainAtlas        = "atlas"
-	PrivilegeDomainBlobstores   = "blobstores"
-	PrivilegeDomainBundles      = "bundles"
-	PrivilegeDomainCapabilities = "capabilities"
-	PrivilegeDomainComponent    = "component"
-	PrivilegeDomainDatastores   = "datastores"
+	PrivilegeDomainAll                = "*"
+	PrivilegeDomainAPIKey             = "apikey"
+	PrivilegeDomainAnalytics          = "analytics"
+	PrivilegeDomainAtlas              = "atlas"
+	PrivilegeDomainBlobstores         = "blobstores"
+	PrivilegeDomainBundles            = "bundles"
+	PrivilegeDomainCapabilities       = "capabilities"
+	PrivilegeDomainComponent          = "component"
+	PrivilegeDomainDatastores         = "datastores"
+	PrivilegeDomainHealthcheck        = "healthcheck"
+	PrivilegeDomainHealthcheckSummary = "healthchecksummary"
+	PrivilegeDomainIQViolationSummery = "iq-violation-summary"
+	PrivilegeDomainLDAP               = "ldap"
+	PrivilegeDomainLicensing          = "licensing"
+	PrivilegeDomainLogging            = "logging"
+	PrivilegeDomainMetrics            = "metrics"
+	PrivilegeDomainPrivileges         = "privileges"
+	PrivilegeDomainRoles              = "roles"
+	PrivilegeDomainSearch             = "search"
+	PrivilegeDomainSelectors          = "selectors"
+	PrivilegeDomainSettings           = "settings"
+	PrivilegeDomainSSLTruststore      = "ssl-truststore"
+	PrivilegeDomainTasks              = "tasks"
+	PrivilegeDomainUsers              = "users"
+	PrivilegeDomainUsersChangePW      = "userschangepw"
+	PrivilegeDomainWonderland         = "wonderland"
 
 	// PrivilegeTypes
 	PrivilegeTypeApplication     = "application"
@@ -32,6 +50,7 @@ const (
 var (
 	// PrivilegeDomains represents a string slice of supported privilege domains
 	PrivilegeDomains []string = []string{
+		PrivilegeDomainAll,
 		PrivilegeDomainAPIKey,
 		PrivilegeDomainAnalytics,
 		PrivilegeDomainAtlas,
@@ -40,6 +59,23 @@ var (
 		PrivilegeDomainCapabilities,
 		PrivilegeDomainComponent,
 		PrivilegeDomainDatastores,
+		PrivilegeDomainHealthcheck,
+		PrivilegeDomainHealthcheckSummary,
+		PrivilegeDomainIQViolationSummery,
+		PrivilegeDomainLDAP,
+		PrivilegeDomainLicensing,
+		PrivilegeDomainLogging,
+		PrivilegeDomainMetrics,
+		PrivilegeDomainPrivileges,
+		PrivilegeDomainRoles,
+		PrivilegeDomainSearch,
+		PrivilegeDomainSelectors,
+		PrivilegeDomainSettings,
+		PrivilegeDomainSSLTruststore,
+		PrivilegeDomainTasks,
+		PrivilegeDomainUsers,
+		PrivilegeDomainUsersChangePW,
+		PrivilegeDomainWonderland,
 	}
 	// PrivilegeTypes represents a string slice of possible privilege types
 	PrivilegeTypes []string = []string{

--- a/privilege.go
+++ b/privilege.go
@@ -22,8 +22,10 @@ const (
 
 	// PrivilegeTypes
 	PrivilegeTypeApplication     = "application"
+	PrivilegeTypeContentSelector = "repository-content-selector"
 	PrivilegeTypeRepositoryAdmin = "repository-admin"
 	PrivilegeTypeRepositoryView  = "repository-view"
+	PrivilegeTypeScript          = "script"
 	PrivilegeTypeWildcard        = "wildcard"
 )
 
@@ -42,8 +44,10 @@ var (
 	// PrivilegeTypes represents a string slice of possible privilege types
 	PrivilegeTypes []string = []string{
 		PrivilegeTypeApplication,
+		PrivilegeTypeContentSelector,
 		PrivilegeTypeRepositoryAdmin,
 		PrivilegeTypeRepositoryView,
+		PrivilegeTypeScript,
 		PrivilegeTypeWildcard,
 	}
 )

--- a/privilege_test.go
+++ b/privilege_test.go
@@ -8,6 +8,110 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestPrivileges(t *testing.T) {
+	client := NewClient(getDefaultConfig())
+
+	privs, err := client.Privileges()
+	assert.Nil(t, err)
+	assert.NotNil(t, privs)
+	assert.Greater(t, len(privs), 0)
+}
+
+func TestPrivilegeTypeWildcardRead(t *testing.T) {
+	client := NewClient(getDefaultConfig())
+	privName := "nx-all"
+
+	priv, err := client.PrivilegeRead(privName)
+	assert.Nil(t, err)
+	assert.NotNil(t, priv)
+	if priv != nil {
+		assert.Equal(t, privName, priv.Name)
+		assert.Equal(t, true, priv.ReadOnly)
+		assert.Equal(t, "nexus:*", priv.Pattern)
+		assert.Equal(t, "All permissions", priv.Description)
+		assert.Equal(t, PrivilegeTypeWildcard, priv.Type)
+		assert.Equal(t, 0, len(priv.Actions))
+	}
+}
+
+func TestPrivilegeTypeAnalyticsRead(t *testing.T) {
+	client := NewClient(getDefaultConfig())
+	privName := "nx-analytics-all"
+
+	priv, err := client.PrivilegeRead(privName)
+	assert.Nil(t, err)
+	assert.NotNil(t, priv)
+	if priv != nil {
+		assert.Equal(t, privName, priv.Name)
+		assert.Equal(t, true, priv.ReadOnly)
+		assert.Equal(t, "All permissions for Analytics", priv.Description)
+		assert.Equal(t, PrivilegeTypeApplication, priv.Type)
+		assert.Equal(t, 1, len(priv.Actions))
+		assert.Equal(t, "ALL", priv.Actions[0])
+		// Attributes of other types
+		assert.Equal(t, "", priv.Format)
+		assert.Equal(t, "", priv.Repository)
+	}
+}
+
+func TestPrivilegeTypeApplicationRead(t *testing.T) {
+	client := NewClient(getDefaultConfig())
+	privName := "nx-apikey-all"
+
+	priv, err := client.PrivilegeRead(privName)
+	assert.Nil(t, err)
+	assert.NotNil(t, priv)
+	if priv != nil {
+		assert.Equal(t, privName, priv.Name)
+		assert.Equal(t, true, priv.ReadOnly)
+		assert.Equal(t, "All permissions for APIKey", priv.Description)
+		assert.Equal(t, PrivilegeTypeApplication, priv.Type)
+		assert.Equal(t, 1, len(priv.Actions))
+		assert.Equal(t, "ALL", priv.Actions[0])
+		// Attributes of other types
+		assert.Equal(t, "", priv.Format)
+		assert.Equal(t, "", priv.Repository)
+	}
+}
+
+func TestPrivilegeTypeRepositoryAdminRead(t *testing.T) {
+	client := NewClient(getDefaultConfig())
+	privName := "nx-repository-admin-*-*-*"
+
+	priv, err := client.PrivilegeRead(privName)
+	assert.Nil(t, err)
+	assert.NotNil(t, priv)
+	if priv != nil {
+		assert.Equal(t, privName, priv.Name)
+		assert.Equal(t, true, priv.ReadOnly)
+		assert.Equal(t, "All privileges for all repository administration", priv.Description)
+		assert.Equal(t, PrivilegeTypeRepositoryAdmin, priv.Type)
+		assert.Equal(t, 1, len(priv.Actions))
+		assert.Equal(t, "ALL", priv.Actions[0])
+		assert.Equal(t, "*", priv.Format)
+		assert.Equal(t, "*", priv.Repository)
+	}
+}
+
+func TestPrivilegeTypeRepositoryViewRead(t *testing.T) {
+	client := NewClient(getDefaultConfig())
+	privName := "nx-repository-view-*-*-*"
+
+	priv, err := client.PrivilegeRead(privName)
+	assert.Nil(t, err)
+	assert.NotNil(t, priv)
+	if priv != nil {
+		assert.Equal(t, privName, priv.Name)
+		assert.Equal(t, true, priv.ReadOnly)
+		assert.Equal(t, "All permissions for all repository views", priv.Description)
+		assert.Equal(t, PrivilegeTypeRepositoryView, priv.Type)
+		assert.Equal(t, 1, len(priv.Actions))
+		assert.Equal(t, "ALL", priv.Actions[0])
+		assert.Equal(t, "*", priv.Format)
+		assert.Equal(t, "*", priv.Repository)
+	}
+}
+
 func TestPrivilegeCreateReadUpdateDelete(t *testing.T) {
 	client := NewClient(getDefaultConfig())
 	privilege := testPrivilege("test-privilege")


### PR DESCRIPTION
- Extend Client by function `Privileges()` that returns a slice of all privileges https://github.com/datadrivers/go-nexus-client/commit/9db4875ef4119d479bb4d80b2e059be6b95b4894
- Add constants and variables that represent supported privilege types and domains https://github.com/datadrivers/go-nexus-client/commit/3b07f32638c08530b334bd797473c549eb3ced5e, https://github.com/datadrivers/go-nexus-client/pull/29/commits/fa2e8096c9898ab6f9c38d3c0e3988e71ce2567e and https://github.com/datadrivers/go-nexus-client/pull/29/commits/ad9393934a3b3212926dd753a8a8c7839e03c9d8
- Add tests for different privilege types and Privileges method https://github.com/datadrivers/go-nexus-client/commit/a8c87f972e6c7c50b7800e75bc5f20a29e3f918d