### PR TITLE
fix the behavior when getting a user from nexus.

### DIFF
--- a/repository.go
+++ b/repository.go
@@ -23,7 +23,7 @@ const (
 	RepositoryFormatP2     = "p2"
 	RepositoryFormatPyPi   = "pypi"
 	RepositoryFormatRAW    = "raw"
-	RepositoryFormatRuby    = "rubygems"
+	RepositoryFormatRuby   = "rubygems"
 	RepositoryFormatYum    = "yum"
 
 	RepositoryTypeGroup  = "group"

--- a/repository_nuget_test.go
+++ b/repository_nuget_test.go
@@ -34,7 +34,7 @@ func getTestRepositoryNugetProxy(name string) Repository {
 		RepositoryCleanup: &RepositoryCleanup{
 			PolicyNames: []string{"weekly-cleanup"},
 		},
-		RepositoryHTTPClient:    &RepositoryHTTPClient{
+		RepositoryHTTPClient: &RepositoryHTTPClient{
 			Connection: &RepositoryHTTPClientConnection{
 				Timeout: makeIntAddressable(20),
 			},

--- a/user.go
+++ b/user.go
@@ -8,7 +8,8 @@ import (
 )
 
 const (
-	usersAPIEndpoint = "service/rest/beta/security/users"
+	usersAPIEndpoint   = "service/rest/beta/security/users"
+	usersAPIEndpointV1 = "service/rest/v1/security/users"
 )
 
 // User ..
@@ -50,7 +51,7 @@ func (c *client) UserCreate(user User) error {
 }
 
 func (c *client) UserRead(id string) (*User, error) {
-	body, resp, err := c.Get(usersAPIEndpoint, nil)
+	body, resp, err := c.Get(fmt.Sprintf("%s?userId=%s", usersAPIEndpointV1, id), nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Instead of getting all the user and then compare ,make the API request to get directly the user, as with the previous behavior when ldap is enabled and the user list is huge, it will timeout before getting a response.