### PR TITLE
fix(): Define RemoteURL as required field

### DIFF
--- a/nexus3/pkg/repository/apt/proxy_test.go
+++ b/nexus3/pkg/repository/apt/proxy_test.go
@@ -33,7 +33,7 @@ func getTestAptProxyRepository(name string) repository.AptProxyRepository {
 		Proxy: repository.Proxy{
 			ContentMaxAge:  1440,
 			MetadataMaxAge: 1440,
-			RemoteURL:      tools.GetStringPointer("https://archive.ubuntu.com/ubuntu/"),
+			RemoteURL:      "https://archive.ubuntu.com/ubuntu/",
 		},
 		Storage: repository.Storage{
 			BlobStoreName:               "default",

--- a/nexus3/pkg/repository/bower/proxy_test.go
+++ b/nexus3/pkg/repository/bower/proxy_test.go
@@ -29,7 +29,7 @@ func getTestBowerProxyRepository(name string) repository.BowerProxyRepository {
 		Proxy: repository.Proxy{
 			ContentMaxAge:  1440,
 			MetadataMaxAge: 1440,
-			RemoteURL:      tools.GetStringPointer("https://archive.ubuntu.com/ubuntu/"),
+			RemoteURL:      "https://archive.ubuntu.com/ubuntu/",
 		},
 		Storage: repository.Storage{
 			BlobStoreName:               "default",

--- a/nexus3/pkg/repository/cocoapods/cocoapods_proxy_test.go
+++ b/nexus3/pkg/repository/cocoapods/cocoapods_proxy_test.go
@@ -29,7 +29,7 @@ func getTestCocoapodsProxyRepository(name string) repository.CocoapodsProxyRepos
 		Proxy: repository.Proxy{
 			ContentMaxAge:  1440,
 			MetadataMaxAge: 1440,
-			RemoteURL:      tools.GetStringPointer("https://archive.ubuntu.com/ubuntu/"),
+			RemoteURL:      "https://archive.ubuntu.com/ubuntu/",
 		},
 		Storage: repository.Storage{
 			BlobStoreName:               "default",

--- a/nexus3/pkg/repository/conan/proxy_test.go
+++ b/nexus3/pkg/repository/conan/proxy_test.go
@@ -29,7 +29,7 @@ func getTestConanProxyRepository(name string) repository.ConanProxyRepository {
 		Proxy: repository.Proxy{
 			ContentMaxAge:  1440,
 			MetadataMaxAge: 1440,
-			RemoteURL:      tools.GetStringPointer("https://archive.ubuntu.com/ubuntu/"),
+			RemoteURL:      "https://archive.ubuntu.com/ubuntu/",
 		},
 		Storage: repository.Storage{
 			BlobStoreName:               "default",

--- a/nexus3/pkg/repository/conda/proxy_test.go
+++ b/nexus3/pkg/repository/conda/proxy_test.go
@@ -29,7 +29,7 @@ func getTestCondaProxyRepository(name string) repository.CondaProxyRepository {
 		Proxy: repository.Proxy{
 			ContentMaxAge:  1440,
 			MetadataMaxAge: 1440,
-			RemoteURL:      tools.GetStringPointer("https://archive.ubuntu.com/ubuntu/"),
+			RemoteURL:      "https://archive.ubuntu.com/ubuntu/",
 		},
 		Storage: repository.Storage{
 			BlobStoreName:               "default",

--- a/nexus3/pkg/repository/docker/docker_proxy_test.go
+++ b/nexus3/pkg/repository/docker/docker_proxy_test.go
@@ -30,7 +30,7 @@ func getTestDockerProxyRepository(name string) repository.DockerProxyRepository 
 		Proxy: repository.Proxy{
 			ContentMaxAge:  1440,
 			MetadataMaxAge: 1440,
-			RemoteURL:      tools.GetStringPointer("https://archive.ubuntu.com/ubuntu/"),
+			RemoteURL:      "https://archive.ubuntu.com/ubuntu/",
 		},
 		Storage: repository.Storage{
 			BlobStoreName:               "default",

--- a/nexus3/pkg/repository/golang/proxy_test.go
+++ b/nexus3/pkg/repository/golang/proxy_test.go
@@ -29,7 +29,7 @@ func getTestGoProxyRepository(name string) repository.GoProxyRepository {
 		Proxy: repository.Proxy{
 			ContentMaxAge:  1440,
 			MetadataMaxAge: 1440,
-			RemoteURL:      tools.GetStringPointer("https://archive.ubuntu.com/ubuntu/"),
+			RemoteURL:      "https://archive.ubuntu.com/ubuntu/",
 		},
 		Storage: repository.Storage{
 			BlobStoreName:               "default",

--- a/nexus3/pkg/repository/helm/proxy_test.go
+++ b/nexus3/pkg/repository/helm/proxy_test.go
@@ -29,7 +29,7 @@ func getTestHelmProxyRepository(name string) repository.HelmProxyRepository {
 		Proxy: repository.Proxy{
 			ContentMaxAge:  1440,
 			MetadataMaxAge: 1440,
-			RemoteURL:      tools.GetStringPointer("https://archive.ubuntu.com/ubuntu/"),
+			RemoteURL:      "https://archive.ubuntu.com/ubuntu/",
 		},
 		Storage: repository.Storage{
 			BlobStoreName:               "default",

--- a/nexus3/pkg/repository/legacy/apt_test.go
+++ b/nexus3/pkg/repository/legacy/apt_test.go
@@ -108,7 +108,7 @@ func getTestLegacyRepositoryAptProxy(name string) repository.LegacyRepository {
 		Proxy: &repository.Proxy{
 			ContentMaxAge:  1440,
 			MetadataMaxAge: 1440,
-			RemoteURL:      tools.GetStringPointer("https://archive.ubuntu.com/ubuntu/"),
+			RemoteURL:      "https://archive.ubuntu.com/ubuntu/",
 		},
 
 		Storage: &repository.HostedStorage{

--- a/nexus3/pkg/repository/legacy/bower_test.go
+++ b/nexus3/pkg/repository/legacy/bower_test.go
@@ -90,7 +90,7 @@ func getTestLegacyRepositoryBowerProxy(name string) repository.LegacyRepository 
 			Enabled: true,
 		},
 		Proxy: &repository.Proxy{
-			RemoteURL: tools.GetStringPointer("https://registry.bower.io"),
+			RemoteURL: "https://registry.bower.io",
 		},
 		Storage: &repository.HostedStorage{
 			BlobStoreName: "default",

--- a/nexus3/pkg/repository/legacy/docker_test.go
+++ b/nexus3/pkg/repository/legacy/docker_test.go
@@ -133,7 +133,7 @@ func getTestLegacyRepositoryDockerProxy(name string) repository.LegacyRepository
 		},
 		NegativeCache: &repository.NegativeCache{},
 		Proxy: &repository.Proxy{
-			RemoteURL: tools.GetStringPointer("https://registry-1.docker.io"),
+			RemoteURL: "https://registry-1.docker.io",
 		},
 		Storage: &repository.HostedStorage{
 			BlobStoreName: "default",

--- a/nexus3/pkg/repository/legacy/nuget_test.go
+++ b/nexus3/pkg/repository/legacy/nuget_test.go
@@ -49,7 +49,7 @@ func getTestLegacyRepositoryNugetProxy(name string) repository.LegacyRepository 
 			NugetVersion:         repository.NugetVersion3,
 		},
 		Proxy: &repository.Proxy{
-			RemoteURL: tools.GetStringPointer("https://www.nuget.org/api/v2/"),
+			RemoteURL: "https://www.nuget.org/api/v2/",
 		},
 		Storage: &repository.HostedStorage{
 			BlobStoreName: "default",

--- a/nexus3/pkg/repository/legacy/pypi_test.go
+++ b/nexus3/pkg/repository/legacy/pypi_test.go
@@ -70,7 +70,7 @@ func getTestLegacyRepositoryPyPiProxy(name string) repository.LegacyRepository {
 			Enabled: true,
 		},
 		Proxy: &repository.Proxy{
-			RemoteURL: tools.GetStringPointer("https://pypi.org/"),
+			RemoteURL: "https://pypi.org/",
 		},
 		Storage: &repository.HostedStorage{
 			BlobStoreName: "default",

--- a/nexus3/pkg/repository/legacy/rubygems_test.go
+++ b/nexus3/pkg/repository/legacy/rubygems_test.go
@@ -65,7 +65,7 @@ func getTestLegacyRepositoryRubyProxy(name string) repository.LegacyRepository {
 			Enabled: true,
 		},
 		Proxy: &repository.Proxy{
-			RemoteURL: tools.GetStringPointer("https://rubygems.org/"),
+			RemoteURL: "https://rubygems.org/",
 		},
 		Storage: &repository.HostedStorage{
 			BlobStoreName: "default",

--- a/nexus3/pkg/repository/maven/proxy_test.go
+++ b/nexus3/pkg/repository/maven/proxy_test.go
@@ -33,7 +33,7 @@ func getTestMavenProxyRepository(name string) repository.MavenProxyRepository {
 		Proxy: repository.Proxy{
 			ContentMaxAge:  1440,
 			MetadataMaxAge: 1440,
-			RemoteURL:      tools.GetStringPointer("https://archive.ubuntu.com/ubuntu/"),
+			RemoteURL:     "https://archive.ubuntu.com/ubuntu/",
 		},
 		Storage: repository.Storage{
 			BlobStoreName:               "default",

--- a/nexus3/pkg/repository/npm/proxy_test.go
+++ b/nexus3/pkg/repository/npm/proxy_test.go
@@ -29,7 +29,7 @@ func getTestNpmProxyRepository(name string) repository.NpmProxyRepository {
 		Proxy: repository.Proxy{
 			ContentMaxAge:  1440,
 			MetadataMaxAge: 1440,
-			RemoteURL:      tools.GetStringPointer("https://archive.ubuntu.com/ubuntu/"),
+			RemoteURL:      "https://archive.ubuntu.com/ubuntu/",
 		},
 		Storage: repository.Storage{
 			BlobStoreName:               "default",

--- a/nexus3/pkg/repository/nuget/proxy_test.go
+++ b/nexus3/pkg/repository/nuget/proxy_test.go
@@ -29,7 +29,7 @@ func getTestNugetProxyRepository(name string) repository.NugetProxyRepository {
 		Proxy: repository.Proxy{
 			ContentMaxAge:  1440,
 			MetadataMaxAge: 1440,
-			RemoteURL:      tools.GetStringPointer("https://api.nuget.org/v3/index.json"),
+			RemoteURL:      "https://api.nuget.org/v3/index.json",
 		},
 		Storage: repository.Storage{
 			BlobStoreName:               "default",
@@ -63,7 +63,7 @@ func TestNugetProxyRepository(t *testing.T) {
 
 	updatedRepo := repo
 	updatedRepo.Online = false
-	updatedRepo.Proxy.RemoteURL = tools.GetStringPointer("https://api.nuget.org/v2/")
+	updatedRepo.Proxy.RemoteURL = "https://api.nuget.org/v2/"
 	updatedRepo.NugetProxy.NugetVersion = repository.NugetVersion2
 
 	err = service.Proxy.Update(repo.Name, updatedRepo)

--- a/nexus3/pkg/repository/p2/proxy_test.go
+++ b/nexus3/pkg/repository/p2/proxy_test.go
@@ -29,7 +29,7 @@ func getTestP2ProxyRepository(name string) repository.P2ProxyRepository {
 		Proxy: repository.Proxy{
 			ContentMaxAge:  1440,
 			MetadataMaxAge: 1440,
-			RemoteURL:      tools.GetStringPointer("https://archive.ubuntu.com/ubuntu/"),
+			RemoteURL:      "https://archive.ubuntu.com/ubuntu/",
 		},
 		Storage: repository.Storage{
 			BlobStoreName:               "default",

--- a/nexus3/pkg/repository/pypi/proxy_test.go
+++ b/nexus3/pkg/repository/pypi/proxy_test.go
@@ -29,7 +29,7 @@ func getTestPypiProxyRepository(name string) repository.PypiProxyRepository {
 		Proxy: repository.Proxy{
 			ContentMaxAge:  1440,
 			MetadataMaxAge: 1440,
-			RemoteURL:      tools.GetStringPointer("https://api.pypi.org/v3/index.json"),
+			RemoteURL:      "https://api.pypi.org/v3/index.json",
 		},
 		Storage: repository.Storage{
 			BlobStoreName:               "default",
@@ -57,7 +57,7 @@ func TestPypiProxyRepository(t *testing.T) {
 
 	updatedRepo := repo
 	updatedRepo.Online = false
-	updatedRepo.Proxy.RemoteURL = tools.GetStringPointer("https://api.pypi.org/v2/")
+	updatedRepo.Proxy.RemoteURL = "https://api.pypi.org/v2/"
 
 	err = service.Proxy.Update(repo.Name, updatedRepo)
 	assert.Nil(t, err)

--- a/nexus3/pkg/repository/r/proxy_test.go
+++ b/nexus3/pkg/repository/r/proxy_test.go
@@ -29,7 +29,7 @@ func getTestRProxyRepository(name string) repository.RProxyRepository {
 		Proxy: repository.Proxy{
 			ContentMaxAge:  1440,
 			MetadataMaxAge: 1440,
-			RemoteURL:      tools.GetStringPointer("https://api.r.org/v3/index.json"),
+			RemoteURL:      "https://api.r.org/v3/index.json",
 		},
 		Storage: repository.Storage{
 			BlobStoreName:               "default",
@@ -57,7 +57,7 @@ func TestRProxyRepository(t *testing.T) {
 
 	updatedRepo := repo
 	updatedRepo.Online = false
-	updatedRepo.Proxy.RemoteURL = tools.GetStringPointer("https://api.r.org/v2/")
+	updatedRepo.Proxy.RemoteURL = "https://api.r.org/v2/"
 
 	err = service.Proxy.Update(repo.Name, updatedRepo)
 	assert.Nil(t, err)

--- a/nexus3/pkg/repository/raw/proxy_test.go
+++ b/nexus3/pkg/repository/raw/proxy_test.go
@@ -29,7 +29,7 @@ func getTestRawProxyRepository(name string) repository.RawProxyRepository {
 		Proxy: repository.Proxy{
 			ContentMaxAge:  1440,
 			MetadataMaxAge: 1440,
-			RemoteURL:      tools.GetStringPointer("https://api.raw.org/v3/index.json"),
+			RemoteURL:      "https://api.raw.org/v3/index.json",
 		},
 		Storage: repository.Storage{
 			BlobStoreName:               "default",
@@ -57,7 +57,7 @@ func TestRawProxyRepository(t *testing.T) {
 
 	updatedRepo := repo
 	updatedRepo.Online = false
-	updatedRepo.Proxy.RemoteURL = tools.GetStringPointer("https://api.raw.org/v2/")
+	updatedRepo.Proxy.RemoteURL = "https://api.raw.org/v2/"
 
 	err = service.Proxy.Update(repo.Name, updatedRepo)
 	assert.Nil(t, err)

--- a/nexus3/pkg/repository/rubygems/proxy_test.go
+++ b/nexus3/pkg/repository/rubygems/proxy_test.go
@@ -29,7 +29,7 @@ func getTestRubyGemsProxyRepository(name string) repository.RubyGemsProxyReposit
 		Proxy: repository.Proxy{
 			ContentMaxAge:  1440,
 			MetadataMaxAge: 1440,
-			RemoteURL:      tools.GetStringPointer("https://api.rubyGems.org/v3/index.json"),
+			RemoteURL:      "https://api.rubyGems.org/v3/index.json",
 		},
 		Storage: repository.Storage{
 			BlobStoreName:               "default",
@@ -57,7 +57,7 @@ func TestRubyGemsProxyRepository(t *testing.T) {
 
 	updatedRepo := repo
 	updatedRepo.Online = false
-	updatedRepo.Proxy.RemoteURL = tools.GetStringPointer("https://api.rubyGems.org/v2/")
+	updatedRepo.Proxy.RemoteURL = "https://api.rubyGems.org/v2/"
 
 	err = service.Proxy.Update(repo.Name, updatedRepo)
 	assert.Nil(t, err)

--- a/nexus3/pkg/repository/yum/proxy_test.go
+++ b/nexus3/pkg/repository/yum/proxy_test.go
@@ -29,7 +29,7 @@ func getTestYumProxyRepository(name string) repository.YumProxyRepository {
 		Proxy: repository.Proxy{
 			ContentMaxAge:  1440,
 			MetadataMaxAge: 1440,
-			RemoteURL:      tools.GetStringPointer("https://api.yum.org/v3/index.json"),
+			RemoteURL:      "https://api.yum.org/v3/index.json",
 		},
 		Storage: repository.Storage{
 			BlobStoreName:               "default",
@@ -63,7 +63,7 @@ func TestYumProxyRepository(t *testing.T) {
 
 	updatedRepo := repo
 	updatedRepo.Online = false
-	updatedRepo.Proxy.RemoteURL = tools.GetStringPointer("https://api.yum.org/v2/")
+	updatedRepo.Proxy.RemoteURL = "https://api.yum.org/v2/"
 
 	err = service.Proxy.Update(repo.Name, updatedRepo)
 	assert.Nil(t, err)

--- a/nexus3/schema/repository/repository.go
+++ b/nexus3/schema/repository/repository.go
@@ -31,7 +31,7 @@ type Proxy struct {
 	MetadataMaxAge int `json:"metadataMaxAge"`
 
 	// Location of the remote repository being proxied
-	RemoteURL *string `json:"remoteUrl,omitempty"`
+	RemoteURL string `json:"remoteUrl"`
 }
 
 // Component ...


### PR DESCRIPTION
In openapi/swagger definition this field is optional, but the REST API requires this attribute