### PR TITLE
fix(repository): Declare BlobStoreName and DockerProxy.IndexType as required attribute

### DIFF
--- a/nexus3/pkg/repository/docker/docker_proxy_test.go
+++ b/nexus3/pkg/repository/docker/docker_proxy_test.go
@@ -11,7 +11,6 @@ import (
 )
 
 func getTestDockerProxyRepository(name string) repository.DockerProxyRepository {
-	proxyIndexType := repository.DockerProxyIndexTypeHub
 	return repository.DockerProxyRepository{
 		Name:   name,
 		Online: true,
@@ -43,7 +42,7 @@ func getTestDockerProxyRepository(name string) repository.DockerProxyRepository 
 			HTTPSPort:      tools.GetIntPointer(8643),
 		},
 		DockerProxy: repository.DockerProxy{
-			IndexType: &proxyIndexType,
+			IndexType: repository.DockerProxyIndexTypeHub,
 		},
 	}
 }

--- a/nexus3/pkg/repository/legacy/docker_test.go
+++ b/nexus3/pkg/repository/legacy/docker_test.go
@@ -110,7 +110,6 @@ func TestLegacyRepositoryDockerProxy(t *testing.T) {
 }
 
 func getTestLegacyRepositoryDockerProxy(name string) repository.LegacyRepository {
-	dockerIndexType := repository.DockerProxyIndexTypeHub
 	return repository.LegacyRepository{
 		Name:   name,
 		Online: true,
@@ -124,7 +123,7 @@ func getTestLegacyRepositoryDockerProxy(name string) repository.LegacyRepository
 			ForceBasicAuth: true,
 		},
 		DockerProxy: &repository.DockerProxy{
-			IndexType: &dockerIndexType,
+			IndexType: repository.DockerProxyIndexTypeHub,
 		},
 		HTTPClient: &repository.HTTPClient{
 			Connection: &repository.HTTPClientConnection{

--- a/nexus3/schema/repository/docker.go
+++ b/nexus3/schema/repository/docker.go
@@ -61,7 +61,7 @@ type Docker struct {
 // DockerProxy contains data of a Docker Proxy Repository
 type DockerProxy struct {
 	// Type of Docker Index
-	IndexType *DockerProxyIndexType `json:"indexType"`
+	IndexType DockerProxyIndexType `json:"indexType"`
 	// Url of Docker Index to use
 	IndexURL *string `json:"indexUrl,omitempty"`
 }

--- a/nexus3/schema/repository/storage.go
+++ b/nexus3/schema/repository/storage.go
@@ -11,7 +11,7 @@ type StorageWritePolicy string
 // HostedStorage contains repository storage for hosted
 type HostedStorage struct {
 	// Blob store used to store repository contents
-	BlobStoreName string `json:"blobStoreName,omitempty"`
+	BlobStoreName string `json:"blobStoreName"`
 
 	// StrictContentTypeValidation: Whether to validate uploaded content's MIME type appropriate for the repository format
 	StrictContentTypeValidation bool `json:"strictContentTypeValidation"`
@@ -23,7 +23,7 @@ type HostedStorage struct {
 // Storage contains repository storage
 type Storage struct {
 	// Blob store used to store repository contents
-	BlobStoreName string `json:"blobStoreName,omitempty"`
+	BlobStoreName string `json:"blobStoreName"`
 
 	// StrictContentTypeValidation: Whether to validate uploaded content's MIME type appropriate for the repository format
 	StrictContentTypeValidation bool `json:"strictContentTypeValidation"`


### PR DESCRIPTION
Declare BlobStoreName as required attribute to fix following error:

```
Error: could not create repository 'XXX': HTTP: 400, [ {
  "id" : "PARAMETER blobStoreName",
  "message" : "must not be empty"
} ]
```