### PR TITLE
fix(blobstore): Change json annotation for members list in group blobstore

### DIFF
--- a/nexus3/schema/blobstore/group.go
+++ b/nexus3/schema/blobstore/group.go
@@ -12,7 +12,7 @@ type Group struct {
 	SoftQuota *SoftQuota `json:"softQuota,omitempty"`
 
 	// List of the names of blob stores that are members of this group
-	Members []string `json:"members,omitempty"`
+	Members []string `json:"members"`
 
 	// Possible values: roundRobin,writeToFirst
 	FillPolicy string `json:"fillPolicy"`


### PR DESCRIPTION
Attribute members is required

fix error of API:
[
  {
    "id": "*",
    "message": "Blob Store 'test-group' cannot be empty"
  }
]