### PR TITLE
fix: Set VersionPolicy and LayoutPolicy as required Fields in Maven struct

### DIFF
--- a/nexus3/pkg/repository/legacy/maven_test.go
+++ b/nexus3/pkg/repository/legacy/maven_test.go
@@ -29,9 +29,7 @@ func TestLegacyRepositoryMavenGroupRead(t *testing.T) {
 
 func TestLegacyRepositoryMavenHosted(t *testing.T) {
 	service := getTestService()
-	layoutPolicy := repository.MavenLayoutPolicyStrict
-	versionPolicy := repository.MavenVersionPolicyRelease
-	repo := getTestLegacyRepositoryMavenHosted("test-legacy-maven-hosted-"+strconv.Itoa(rand.Intn(1024)), &layoutPolicy, &versionPolicy)
+	repo := getTestLegacyRepositoryMavenHosted("test-legacy-maven-hosted-"+strconv.Itoa(rand.Intn(1024)), repository.MavenLayoutPolicyStrict, repository.MavenVersionPolicyRelease)
 
 	err := service.Create(repo)
 	assert.Nil(t, err)
@@ -41,8 +39,7 @@ func TestLegacyRepositoryMavenHosted(t *testing.T) {
 	assert.NotNil(t, createdRepo)
 
 	writePolicy := (repository.StorageWritePolicy)("ALLOW")
-	layoutPolicy = repository.MavenLayoutPolicyPermissive
-	createdRepo.Maven.LayoutPolicy = &layoutPolicy
+	createdRepo.Maven.LayoutPolicy = repository.MavenLayoutPolicyPermissive
 	createdRepo.Storage.WritePolicy = &writePolicy
 	err = service.Update(createdRepo.Name, *createdRepo)
 	assert.Nil(t, err)
@@ -50,7 +47,7 @@ func TestLegacyRepositoryMavenHosted(t *testing.T) {
 	updatedRepo, err := service.Get(createdRepo.Name)
 	assert.Nil(t, err)
 	assert.NotNil(t, updatedRepo)
-	assert.Equal(t, repository.MavenLayoutPolicyPermissive, *updatedRepo.Maven.LayoutPolicy)
+	assert.Equal(t, repository.MavenLayoutPolicyPermissive, updatedRepo.Maven.LayoutPolicy)
 	assert.Equal(t, repository.StorageWritePolicyAllow, *updatedRepo.Storage.WritePolicy)
 
 	err = service.Delete(createdRepo.Name)
@@ -58,7 +55,7 @@ func TestLegacyRepositoryMavenHosted(t *testing.T) {
 
 }
 
-func getTestLegacyRepositoryMavenHosted(name string, layoutPolicy *repository.MavenLayoutPolicy, versionPolicy *repository.MavenVersionPolicy) repository.LegacyRepository {
+func getTestLegacyRepositoryMavenHosted(name string, layoutPolicy repository.MavenLayoutPolicy, versionPolicy repository.MavenVersionPolicy) repository.LegacyRepository {
 	return repository.LegacyRepository{
 		Name:   name,
 		Format: repository.RepositoryFormatMaven2,

--- a/nexus3/pkg/repository/maven/hosted_test.go
+++ b/nexus3/pkg/repository/maven/hosted_test.go
@@ -11,8 +11,6 @@ import (
 
 func getTestMavenHostedRepository(name string) repository.MavenHostedRepository {
 	writePolicy := repository.StorageWritePolicyAllow
-	versionPolicy := repository.MavenVersionPolicySnapshot
-	layoutPolicy := repository.MavenLayoutPolicyStrict
 	return repository.MavenHostedRepository{
 		Name:   name,
 		Online: true,
@@ -26,8 +24,8 @@ func getTestMavenHostedRepository(name string) repository.MavenHostedRepository 
 			WritePolicy:                 &writePolicy,
 		},
 		Maven: repository.Maven{
-			VersionPolicy: &versionPolicy,
-			LayoutPolicy:  &layoutPolicy,
+			VersionPolicy: repository.MavenVersionPolicySnapshot,
+			LayoutPolicy:  repository.MavenLayoutPolicyStrict,
 		},
 	}
 }
@@ -47,8 +45,7 @@ func TestMavenHostedRepository(t *testing.T) {
 
 	updatedRepo := repo
 	updatedRepo.Online = false
-	newVersionPolicy := repository.MavenVersionPolicyMixed
-	updatedRepo.VersionPolicy = &newVersionPolicy
+	updatedRepo.VersionPolicy = repository.MavenVersionPolicyMixed
 
 	err = service.Hosted.Update(repo.Name, updatedRepo)
 	assert.Nil(t, err)

--- a/nexus3/pkg/repository/maven/proxy_test.go
+++ b/nexus3/pkg/repository/maven/proxy_test.go
@@ -11,8 +11,6 @@ import (
 )
 
 func getTestMavenProxyRepository(name string) repository.MavenProxyRepository {
-	versionPolicy := repository.MavenVersionPolicyRelease
-	layoutPolicy := repository.MavenLayoutPolicyStrict
 	return repository.MavenProxyRepository{
 		Name:   name,
 		Online: true,
@@ -40,8 +38,8 @@ func getTestMavenProxyRepository(name string) repository.MavenProxyRepository {
 			StrictContentTypeValidation: true,
 		},
 		Maven: repository.Maven{
-			VersionPolicy: &versionPolicy,
-			LayoutPolicy:  &layoutPolicy,
+			VersionPolicy: repository.MavenVersionPolicyRelease,
+			LayoutPolicy:  repository.MavenLayoutPolicyStrict,
 		},
 	}
 }
@@ -65,11 +63,10 @@ func TestMavenProxyRepository(t *testing.T) {
 	assert.Equal(t, repo.Storage, generatedRepo.Storage)
 	assert.Equal(t, repo.Maven, generatedRepo.Maven)
 
-	newLayoutPolicy := repository.MavenLayoutPolicyPermissive
 	updatedRepo := repo
 	updatedRepo.Online = false
 	updatedRepo.HTTPClient.Authentication.Preemptive = tools.GetBoolPointer(true)
-	updatedRepo.LayoutPolicy = &newLayoutPolicy
+	updatedRepo.LayoutPolicy = repository.MavenLayoutPolicyPermissive
 
 	err = service.Proxy.Update(repo.Name, updatedRepo)
 	assert.Nil(t, err)

--- a/nexus3/schema/repository/maven.go
+++ b/nexus3/schema/repository/maven.go
@@ -63,7 +63,7 @@ type MavenProxyRepository struct {
 
 // Maven contains additional data of maven repository
 type Maven struct {
-	VersionPolicy      *MavenVersionPolicy      `json:"versionPolicy,omitempty"`
-	LayoutPolicy       *MavenLayoutPolicy       `json:"layoutPolicy,omitempty"`
+	VersionPolicy      MavenVersionPolicy       `json:"versionPolicy"`
+	LayoutPolicy       MavenLayoutPolicy        `json:"layoutPolicy"`
 	ContentDisposition *MavenContentDisposition `json:"contentDisposition,omitempty"`
 }


### PR DESCRIPTION
In swagger.yaml are these fields as optional but Nexus API requires them