### PR TITLE
Adding in the feature to allow for subdomain connector

### DIFF
--- a/nexus3/pkg/repository/docker/docker_group_test.go
+++ b/nexus3/pkg/repository/docker/docker_group_test.go
@@ -27,6 +27,27 @@ func getTestDockerGroupRepository(name string) repository.DockerGroupRepository 
 			V1Enabled:      false,
 			HTTPPort:       tools.GetIntPointer(8080),
 			HTTPSPort:      tools.GetIntPointer(8443),
+		},
+	}
+}
+
+func getTestProDockerGroupRepository(name string) repository.DockerGroupRepository {
+	return repository.DockerGroupRepository{
+		Name:   name,
+		Online: true,
+
+		Group: repository.GroupDeploy{
+			MemberNames: []string{},
+		},
+		Storage: repository.Storage{
+			BlobStoreName:               "default",
+			StrictContentTypeValidation: true,
+		},
+		Docker: repository.Docker{
+			ForceBasicAuth: true,
+			V1Enabled:      false,
+			HTTPPort:       tools.GetIntPointer(8080),
+			HTTPSPort:      tools.GetIntPointer(8443),
 			Subdomain:      tools.GetStringPointer(name),
 		},
 	}
@@ -35,6 +56,43 @@ func getTestDockerGroupRepository(name string) repository.DockerGroupRepository 
 func TestDockerGroupRepository(t *testing.T) {
 	service := getTestService()
 	repo := getTestDockerGroupRepository("test-docker-repo-group-" + strconv.Itoa(rand.Intn(1024)))
+
+	testProxyRepo := getTestDockerProxyRepository("test-docker-group-proxy-" + strconv.Itoa(rand.Intn(1024)))
+	defer service.Proxy.Delete(testProxyRepo.Name)
+	err := service.Proxy.Create(testProxyRepo)
+	assert.Nil(t, err)
+	repo.Group.MemberNames = append(repo.Group.MemberNames, testProxyRepo.Name)
+
+	err = service.Group.Create(repo)
+	assert.Nil(t, err)
+	generatedRepo, err := service.Group.Get(repo.Name)
+	assert.Nil(t, err)
+	assert.Equal(t, repo.Online, generatedRepo.Online)
+	assert.Equal(t, repo.Group, generatedRepo.Group)
+	assert.Equal(t, repo.Storage, generatedRepo.Storage)
+	assert.Equal(t, repo.Docker, generatedRepo.Docker)
+
+	updatedRepo := repo
+	updatedRepo.Online = false
+	updatedRepo.ForceBasicAuth = false
+
+	err = service.Group.Update(repo.Name, updatedRepo)
+	assert.Nil(t, err)
+	generatedRepo, err = service.Group.Get(updatedRepo.Name)
+	assert.Nil(t, err)
+	assert.Equal(t, updatedRepo.Online, generatedRepo.Online)
+	assert.Equal(t, updatedRepo.ForceBasicAuth, generatedRepo.ForceBasicAuth)
+
+	service.Group.Delete(repo.Name)
+	assert.Nil(t, err)
+}
+
+func TestProDockerGroupRepository(t *testing.T) {
+	if tools.GetEnv("SKIP_PRO_TESTS", "false") == "true" {
+		t.Skip("Skipping Nexus Pro tests")
+	}
+	service := getTestService()
+	repo := getTestProDockerGroupRepository("test-docker-repo-group-" + strconv.Itoa(rand.Intn(1024)))
 
 	testProxyRepo := getTestDockerProxyRepository("test-docker-group-proxy-" + strconv.Itoa(rand.Intn(1024)))
 	defer service.Proxy.Delete(testProxyRepo.Name)

--- a/nexus3/pkg/repository/docker/docker_group_test.go
+++ b/nexus3/pkg/repository/docker/docker_group_test.go
@@ -27,6 +27,7 @@ func getTestDockerGroupRepository(name string) repository.DockerGroupRepository 
 			V1Enabled:      false,
 			HTTPPort:       tools.GetIntPointer(8080),
 			HTTPSPort:      tools.GetIntPointer(8443),
+			Subdomain:		tools.GetStringPointer(name),
 		},
 	}
 }

--- a/nexus3/pkg/repository/docker/docker_group_test.go
+++ b/nexus3/pkg/repository/docker/docker_group_test.go
@@ -27,7 +27,7 @@ func getTestDockerGroupRepository(name string) repository.DockerGroupRepository 
 			V1Enabled:      false,
 			HTTPPort:       tools.GetIntPointer(8080),
 			HTTPSPort:      tools.GetIntPointer(8443),
-			Subdomain:		tools.GetStringPointer(name),
+			Subdomain:      tools.GetStringPointer(name),
 		},
 	}
 }

--- a/nexus3/pkg/repository/docker/docker_hosted_test.go
+++ b/nexus3/pkg/repository/docker/docker_hosted_test.go
@@ -32,6 +32,32 @@ func getTestDockerHostedRepository(name string) repository.DockerHostedRepositor
 			V1Enabled:      false,
 			HTTPPort:       tools.GetIntPointer(8180),
 			HTTPSPort:      tools.GetIntPointer(8543),
+		},
+	}
+}
+
+func getTestProDockerHostedRepository(name string) repository.DockerHostedRepository {
+	writePolicy := repository.StorageWritePolicyAllow
+	return repository.DockerHostedRepository{
+		Name:   name,
+		Online: true,
+
+		Cleanup: &repository.Cleanup{
+			PolicyNames: []string{"weekly-cleanup"},
+		},
+		Storage: repository.HostedStorage{
+			BlobStoreName:               "default",
+			StrictContentTypeValidation: true,
+			WritePolicy:                 &writePolicy,
+		},
+		Component: &repository.Component{
+			ProprietaryComponents: true,
+		},
+		Docker: repository.Docker{
+			ForceBasicAuth: true,
+			V1Enabled:      false,
+			HTTPPort:       tools.GetIntPointer(8180),
+			HTTPSPort:      tools.GetIntPointer(8543),
 			Subdomain:      tools.GetStringPointer(name),
 		},
 	}
@@ -40,6 +66,38 @@ func getTestDockerHostedRepository(name string) repository.DockerHostedRepositor
 func TestDockerHostedRepository(t *testing.T) {
 	service := getTestService()
 	repo := getTestDockerHostedRepository("test-docker-repo-hosted-" + strconv.Itoa(rand.Intn(1024)))
+
+	err := service.Hosted.Create(repo)
+	assert.Nil(t, err)
+	generatedRepo, err := service.Hosted.Get(repo.Name)
+	assert.Nil(t, err)
+	assert.Equal(t, repo.Online, generatedRepo.Online)
+	assert.Equal(t, repo.Cleanup, generatedRepo.Cleanup)
+	assert.Equal(t, repo.Storage, generatedRepo.Storage)
+	assert.Equal(t, repo.Component, generatedRepo.Component)
+	assert.Equal(t, repo.Docker, generatedRepo.Docker)
+
+	updatedRepo := repo
+	updatedRepo.Online = false
+	updatedRepo.V1Enabled = true
+
+	err = service.Hosted.Update(repo.Name, updatedRepo)
+	assert.Nil(t, err)
+	generatedRepo, err = service.Hosted.Get(updatedRepo.Name)
+	assert.Nil(t, err)
+	assert.Equal(t, updatedRepo.Online, generatedRepo.Online)
+	assert.Equal(t, updatedRepo.V1Enabled, generatedRepo.V1Enabled)
+
+	service.Hosted.Delete(repo.Name)
+	assert.Nil(t, err)
+}
+
+func TestProDockerHostedRepository(t *testing.T) {
+	if tools.GetEnv("SKIP_PRO_TESTS", "false") == "true" {
+		t.Skip("Skipping Nexus Pro tests")
+	}
+	service := getTestService()
+	repo := getTestProDockerHostedRepository("test-docker-repo-hosted-" + strconv.Itoa(rand.Intn(1024)))
 
 	err := service.Hosted.Create(repo)
 	assert.Nil(t, err)

--- a/nexus3/pkg/repository/docker/docker_hosted_test.go
+++ b/nexus3/pkg/repository/docker/docker_hosted_test.go
@@ -32,6 +32,7 @@ func getTestDockerHostedRepository(name string) repository.DockerHostedRepositor
 			V1Enabled:      false,
 			HTTPPort:       tools.GetIntPointer(8180),
 			HTTPSPort:      tools.GetIntPointer(8543),
+			Subdomain:		tools.GetStringPointer(name),
 		},
 	}
 }

--- a/nexus3/pkg/repository/docker/docker_hosted_test.go
+++ b/nexus3/pkg/repository/docker/docker_hosted_test.go
@@ -32,7 +32,7 @@ func getTestDockerHostedRepository(name string) repository.DockerHostedRepositor
 			V1Enabled:      false,
 			HTTPPort:       tools.GetIntPointer(8180),
 			HTTPSPort:      tools.GetIntPointer(8543),
-			Subdomain:		tools.GetStringPointer(name),
+			Subdomain:      tools.GetStringPointer(name),
 		},
 	}
 }

--- a/nexus3/pkg/repository/docker/docker_proxy_test.go
+++ b/nexus3/pkg/repository/docker/docker_proxy_test.go
@@ -40,7 +40,7 @@ func getTestDockerProxyRepository(name string) repository.DockerProxyRepository 
 			V1Enabled:      false,
 			HTTPPort:       tools.GetIntPointer(8280),
 			HTTPSPort:      tools.GetIntPointer(8643),
-			Subdomain:		tools.GetStringPointer(name),
+			Subdomain:      tools.GetStringPointer(name),
 		},
 		DockerProxy: repository.DockerProxy{
 			IndexType: repository.DockerProxyIndexTypeHub,

--- a/nexus3/pkg/repository/docker/docker_proxy_test.go
+++ b/nexus3/pkg/repository/docker/docker_proxy_test.go
@@ -40,6 +40,7 @@ func getTestDockerProxyRepository(name string) repository.DockerProxyRepository 
 			V1Enabled:      false,
 			HTTPPort:       tools.GetIntPointer(8280),
 			HTTPSPort:      tools.GetIntPointer(8643),
+			Subdomain:		tools.GetStringPointer(name),
 		},
 		DockerProxy: repository.DockerProxy{
 			IndexType: repository.DockerProxyIndexTypeHub,

--- a/nexus3/pkg/repository/docker/docker_proxy_test.go
+++ b/nexus3/pkg/repository/docker/docker_proxy_test.go
@@ -40,6 +40,43 @@ func getTestDockerProxyRepository(name string) repository.DockerProxyRepository 
 			V1Enabled:      false,
 			HTTPPort:       tools.GetIntPointer(8280),
 			HTTPSPort:      tools.GetIntPointer(8643),
+		},
+		DockerProxy: repository.DockerProxy{
+			IndexType: repository.DockerProxyIndexTypeHub,
+		},
+	}
+}
+
+func getTestProDockerProxyRepository(name string) repository.DockerProxyRepository {
+	return repository.DockerProxyRepository{
+		Name:   name,
+		Online: true,
+		HTTPClient: repository.HTTPClient{
+			Blocked:   true,
+			AutoBlock: true,
+			Connection: &repository.HTTPClientConnection{
+				Timeout:       tools.GetIntPointer(20),
+				UseTrustStore: tools.GetBoolPointer(true),
+			},
+		},
+		NegativeCache: repository.NegativeCache{
+			Enabled: true,
+			TTL:     1440,
+		},
+		Proxy: repository.Proxy{
+			ContentMaxAge:  1440,
+			MetadataMaxAge: 1440,
+			RemoteURL:      "https://archive.ubuntu.com/ubuntu/",
+		},
+		Storage: repository.Storage{
+			BlobStoreName:               "default",
+			StrictContentTypeValidation: true,
+		},
+		Docker: repository.Docker{
+			ForceBasicAuth: true,
+			V1Enabled:      false,
+			HTTPPort:       tools.GetIntPointer(8280),
+			HTTPSPort:      tools.GetIntPointer(8643),
 			Subdomain:      tools.GetStringPointer(name),
 		},
 		DockerProxy: repository.DockerProxy{
@@ -51,6 +88,42 @@ func getTestDockerProxyRepository(name string) repository.DockerProxyRepository 
 func TestDockerProxyRepository(t *testing.T) {
 	service := getTestService()
 	repo := getTestDockerProxyRepository("test-docker-repo-hosted-" + strconv.Itoa(rand.Intn(1024)))
+
+	err := service.Proxy.Create(repo)
+	assert.Nil(t, err)
+	generatedRepo, err := service.Proxy.Get(repo.Name)
+	assert.Nil(t, err)
+	assert.Equal(t, repo.Online, generatedRepo.Online)
+	assert.Equal(t, repo.HTTPClient.Blocked, generatedRepo.HTTPClient.Blocked)
+	assert.Equal(t, repo.HTTPClient.AutoBlock, generatedRepo.HTTPClient.AutoBlock)
+	assert.Equal(t, repo.HTTPClient.Connection.Timeout, generatedRepo.HTTPClient.Connection.Timeout)
+	assert.Equal(t, repo.HTTPClient.Connection.UseTrustStore, generatedRepo.HTTPClient.Connection.UseTrustStore)
+	assert.Equal(t, repo.NegativeCache, generatedRepo.NegativeCache)
+	assert.Equal(t, repo.Proxy, generatedRepo.Proxy)
+	assert.Equal(t, repo.Storage, generatedRepo.Storage)
+	assert.Equal(t, repo.Docker, generatedRepo.Docker)
+	assert.Equal(t, repo.DockerProxy, generatedRepo.DockerProxy)
+
+	updatedRepo := repo
+	updatedRepo.Online = false
+
+	err = service.Proxy.Update(repo.Name, updatedRepo)
+	assert.Nil(t, err)
+	generatedRepo, err = service.Proxy.Get(updatedRepo.Name)
+	assert.Nil(t, err)
+	assert.Equal(t, updatedRepo.Online, generatedRepo.Online)
+	assert.Equal(t, updatedRepo.Docker, generatedRepo.Docker)
+
+	service.Proxy.Delete(repo.Name)
+	assert.Nil(t, err)
+}
+
+func TestProDockerProxyRepository(t *testing.T) {
+	if tools.GetEnv("SKIP_PRO_TESTS", "false") == "true" {
+		t.Skip("Skipping Nexus Pro tests")
+	}
+	service := getTestService()
+	repo := getTestProDockerProxyRepository("test-docker-repo-hosted-" + strconv.Itoa(rand.Intn(1024)))
 
 	err := service.Proxy.Create(repo)
 	assert.Nil(t, err)

--- a/nexus3/schema/repository/docker.go
+++ b/nexus3/schema/repository/docker.go
@@ -56,6 +56,8 @@ type Docker struct {
 	HTTPSPort *int `json:"httpsPort,omitempty"`
 	// Whether to allow clients to use the V1 API to interact with this repository
 	V1Enabled bool `json:"v1Enabled"`
+	// Whether to allow subdomain connector at the specified subdomain
+	Subdomain *string `json:"subdomain,omitempty"`
 }
 
 // DockerProxy contains data of a Docker Proxy Repository


### PR DESCRIPTION
This will be a required change to address this issue:

https://github.com/datadrivers/terraform-provider-nexus/issues/368

The "subdomain" attribute allows for a subdomain connector to be enabled to avoid having to use special http and https ports.

I have a working PR for terraform-provider-nexus. Incoming.