### PR TITLE
Pin GitHub Actions using Frizbee

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -24,15 +24,15 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@319cdb9fa619417d07cc37a964f0502bfbc5e8a9 # v3
         with:
           languages: ${{ matrix.language }}
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v3
+        uses: github/codeql-action/autobuild@319cdb9fa619417d07cc37a964f0502bfbc5e8a9 # v3
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@319cdb9fa619417d07cc37a964f0502bfbc5e8a9 # v3

--- a/.github/workflows/feature-branches.yaml
+++ b/.github/workflows/feature-branches.yaml
@@ -10,9 +10,9 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout source codes
-        uses: actions/checkout@v4
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
       - name: Install Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5
         with:
           go-version: ${{ matrix.go-version }}
       - name: Test client with nexus3 instance


### PR DESCRIPTION
Hey there 👋

I work on an open source security project ([Frizbee](https://github.com/stacklok/frizbee)) that can automatically pin GitHub Actions to digests (instead of floating tags). 

The Frizbee team is trying to spread the word to open source maintainers about the need for this, because pinning your actions to commit hashes is the *only* way to get an immutable pointer to a specific revision. If an action’s source code repo is compromised by a malicious actor, you’ll still be referencing a known-good version and your project won’t be at risk. 

The following PR pins your actions to their commit hash and it was done using the [frizbee](https://github.com/stacklok/frizbee) CLI. Frizbee also appends a comment so you can easily see which version this digest corresponds to.

Note that Dependabot supports updating pinned actions and will continue to update them.

If you liked it and also want to keep this consistent in case you add more unpinned actions in future, there's a [frizbee-action](https://github.com/stacklok/frizbee-action) which you can use to help automate this.

Thanks!