### PR TITLE
ci: Fix docker compose command for pipeline

### DIFF
--- a/scripts/start-services.sh
+++ b/scripts/start-services.sh
@@ -4,6 +4,6 @@ set -eo pipefail
 source ./script.source
 
 echo "Starting Nexus ${NEXUS_TYPE} and other required services..."
-docker-compose up -d
+docker compose up -d
 
 ./wait-for-nexus.sh

--- a/scripts/stop-services.sh
+++ b/scripts/stop-services.sh
@@ -4,4 +4,4 @@ set -eo pipefail
 source ./script.source
 
 echo "Stopping the services..."
-docker-compose down
+docker compose down


### PR DESCRIPTION
the program docker-compose itself is imported into docker command and deprecated