### PR TITLE
fix: mark cleanup policy test as pro feature

### DIFF
--- a/nexus3/pkg/cleanup/service_test.go
+++ b/nexus3/pkg/cleanup/service_test.go
@@ -43,6 +43,10 @@ func TestNewCleanupService(t *testing.T) {
 }
 
 func TestCreateCleanupPolicy(t *testing.T) {
+	if tools.GetEnv("SKIP_PRO_TESTS", "false") == "true" {
+		t.Skip("Skipping Nexus Pro tests")
+	}
+
 	s := getTestService()
 
 	policy := &cleanuppolicies.CleanupPolicy{


### PR DESCRIPTION
Skip cleanup policy tests when not running pro version