### PR TITLE
fix: include HTTP status code in error messages to prevent empty diagnostics

### DIFF
--- a/nexus3/mail_config.go
+++ b/nexus3/mail_config.go
@@ -31,7 +31,7 @@ func (s *MailConfigService) Get() (*schema.MailConfig, error) {
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("%s", string(body))
+		return nil, fmt.Errorf("could not get mail config: HTTP %d, %s", resp.StatusCode, string(body))
 	}
 	var mailconfig schema.MailConfig
 	if err := json.Unmarshal(body, &mailconfig); err != nil {
@@ -51,7 +51,7 @@ func (s *MailConfigService) Create(mailconfig *schema.MailConfig) error {
 	}
 
 	if resp.StatusCode != http.StatusNoContent {
-		return fmt.Errorf("%s", string(body))
+		return fmt.Errorf("could not create mail config: HTTP %d, %s", resp.StatusCode, string(body))
 	}
 
 	return nil
@@ -69,7 +69,7 @@ func (s *MailConfigService) Update(mailconfig *schema.MailConfig) error {
 	}
 
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
-		return fmt.Errorf("%s", string(body))
+		return fmt.Errorf("could not update mail config: HTTP %d, %s", resp.StatusCode, string(body))
 	}
 
 	return nil
@@ -82,7 +82,7 @@ func (s *MailConfigService) Delete() error {
 	}
 
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
-		return fmt.Errorf("%s", string(body))
+		return fmt.Errorf("could not delete mail config: HTTP %d, %s", resp.StatusCode, string(body))
 	}
 	return err
 }

--- a/nexus3/pkg/security/privilege/service.go
+++ b/nexus3/pkg/security/privilege/service.go
@@ -85,7 +85,7 @@ func (s SecurityPrivilegeService) Delete(name string) error {
 	}
 
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
-		return fmt.Errorf("%s", string(body))
+		return fmt.Errorf("could not delete privilege '%s': HTTP %d, %s", name, resp.StatusCode, string(body))
 	}
 	return err
 }

--- a/nexus3/pkg/security/role.go
+++ b/nexus3/pkg/security/role.go
@@ -47,7 +47,7 @@ func (s *SecurityRoleService) Create(role security.Role) error {
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("%s", string(body))
+		return fmt.Errorf("could not create role: HTTP %d, %s", resp.StatusCode, string(body))
 	}
 
 	return nil
@@ -62,7 +62,7 @@ func (s *SecurityRoleService) Get(id string) (*security.Role, error) {
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("%s", string(body))
+		return nil, fmt.Errorf("could not get role '%s': HTTP %d, %s", id, resp.StatusCode, string(body))
 	}
 
 	var role security.Role
@@ -87,7 +87,7 @@ func (s *SecurityRoleService) Update(id string, role security.Role) error {
 	}
 
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
-		return fmt.Errorf("%s", string(body))
+		return fmt.Errorf("could not update role '%s': HTTP %d, %s", id, resp.StatusCode, string(body))
 	}
 
 	return nil
@@ -102,7 +102,7 @@ func (s *SecurityRoleService) Delete(id string) error {
 	}
 
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
-		return fmt.Errorf("%s", string(body))
+		return fmt.Errorf("could not delete role '%s': HTTP %d, %s", id, resp.StatusCode, string(body))
 	}
 
 	return nil

--- a/nexus3/pkg/security/user.go
+++ b/nexus3/pkg/security/user.go
@@ -46,7 +46,7 @@ func (s *SecurityUserService) Create(user security.User) error {
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("%s", string(body))
+		return fmt.Errorf("could not create user: HTTP %d, %s", resp.StatusCode, string(body))
 	}
 
 	return nil
@@ -72,7 +72,7 @@ func (s *SecurityUserService) Get(id string, source *string) (*security.User, er
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("%s", string(body))
+		return nil, fmt.Errorf("could not get user '%s': HTTP %d, %s", id, resp.StatusCode, string(body))
 	}
 
 	users, err := jsonUnmarshalUsers(body)
@@ -106,7 +106,7 @@ func (s *SecurityUserService) Update(id string, user security.User) error {
 	}
 
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
-		return fmt.Errorf("%s", string(body))
+		return fmt.Errorf("could not update user '%s': HTTP %d, %s", id, resp.StatusCode, string(body))
 	}
 
 	return nil
@@ -119,7 +119,7 @@ func (s *SecurityUserService) Delete(id string) error {
 	}
 
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
-		return fmt.Errorf("%s", string(body))
+		return fmt.Errorf("could not delete user '%s': HTTP %d, %s", id, resp.StatusCode, string(body))
 	}
 	return err
 }
@@ -160,7 +160,7 @@ func (s *SecurityUserService) List(source *string) ([]security.User, error) {
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("%s", string(body))
+		return nil, fmt.Errorf("could not list users: HTTP %d, %s", resp.StatusCode, string(body))
 	}
 
 	users, err := jsonUnmarshalUsers(body)

--- a/nexus3/routing_rule.go
+++ b/nexus3/routing_rule.go
@@ -30,7 +30,7 @@ func (s *RoutingRuleService) Lists() ([]schema.RoutingRule, error) {
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("%s", string(body))
+		return nil, fmt.Errorf("could not list routing rules: HTTP %d, %s", resp.StatusCode, string(body))
 	}
 
 	var rules []schema.RoutingRule
@@ -47,7 +47,7 @@ func (s *RoutingRuleService) Get(name string) (*schema.RoutingRule, error) {
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("%s", string(body))
+		return nil, fmt.Errorf("could not get routing rule '%s': HTTP %d, %s", name, resp.StatusCode, string(body))
 	}
 	var rule schema.RoutingRule
 	if err := json.Unmarshal(body, &rule); err != nil {
@@ -70,7 +70,7 @@ func (s *RoutingRuleService) Create(rule *schema.RoutingRule) error {
 	}
 
 	if resp.StatusCode != http.StatusNoContent {
-		return fmt.Errorf("%s", string(body))
+		return fmt.Errorf("could not create routing rule: HTTP %d, %s", resp.StatusCode, string(body))
 	}
 
 	return nil
@@ -88,7 +88,7 @@ func (s *RoutingRuleService) Update(rule *schema.RoutingRule) error {
 	}
 
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
-		return fmt.Errorf("%s", string(body))
+		return fmt.Errorf("could not update routing rule '%s': HTTP %d, %s", rule.Name, resp.StatusCode, string(body))
 	}
 
 	return nil
@@ -101,7 +101,7 @@ func (s *RoutingRuleService) Delete(name string) error {
 	}
 
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
-		return fmt.Errorf("%s", string(body))
+		return fmt.Errorf("could not delete routing rule '%s': HTTP %d, %s", name, resp.StatusCode, string(body))
 	}
 	return err
 }

--- a/nexus3/script.go
+++ b/nexus3/script.go
@@ -32,7 +32,7 @@ func (s *ScriptService) List() ([]schema.Script, error) {
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("%s", string(body))
+		return nil, fmt.Errorf("could not list scripts: HTTP %d, %s", resp.StatusCode, string(body))
 	}
 
 	var scripts []schema.Script
@@ -49,7 +49,7 @@ func (s *ScriptService) Get(name string) (*schema.Script, error) {
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("%s", string(body))
+		return nil, fmt.Errorf("could not get script '%s': HTTP %d, %s", name, resp.StatusCode, string(body))
 	}
 	var script schema.Script
 	if err := json.Unmarshal(body, &script); err != nil {
@@ -69,7 +69,7 @@ func (s *ScriptService) Create(script *schema.Script) error {
 	}
 
 	if resp.StatusCode != http.StatusNoContent {
-		return fmt.Errorf("%s", string(body))
+		return fmt.Errorf("could not create script: HTTP %d, %s", resp.StatusCode, string(body))
 	}
 
 	return nil
@@ -87,7 +87,7 @@ func (s *ScriptService) Update(script *schema.Script) error {
 	}
 
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
-		return fmt.Errorf("%s", string(body))
+		return fmt.Errorf("could not update script '%s': HTTP %d, %s", script.Name, resp.StatusCode, string(body))
 	}
 
 	return nil
@@ -100,7 +100,7 @@ func (s *ScriptService) Delete(name string) error {
 	}
 
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
-		return fmt.Errorf("%s", string(body))
+		return fmt.Errorf("could not delete script '%s': HTTP %d, %s", name, resp.StatusCode, string(body))
 	}
 	return err
 }
@@ -112,7 +112,7 @@ func (s *ScriptService) Run(name string) error {
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("%s", string(body))
+		return fmt.Errorf("could not run script '%s': HTTP %d, %s", name, resp.StatusCode, string(body))
 	}
 	return err
 }
@@ -124,7 +124,7 @@ func (s *ScriptService) RunWithPayload(name, payload string) error {
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("%s", string(body))
+		return fmt.Errorf("could not run script '%s' with payload: HTTP %d, %s", name, resp.StatusCode, string(body))
 	}
 	return err
 }


### PR DESCRIPTION
## Summary

When Nexus returns a non-200 HTTP response with an **empty body** (which happens on 401 Unauthorized and 403 Forbidden), the current error handling produces an error with an empty message:

```go
return nil, fmt.Errorf("%s", string(body))  // body is empty → error message is ""
```

This causes Terraform to display the unhelpful diagnostic:
```
Error: Empty Summary: This is always a bug in the provider and should be reported to the provider developers.
```

Instead of a clear message like:
```
Error: could not get role 'developer': HTTP 401,
```

## Changes

Updated all 26 occurrences of `fmt.Errorf("%s", string(body))` across 6 files to include:
- HTTP status code
- Resource type and identifier (where available)
- Descriptive action context (get/create/update/delete)

### Files changed:
- `nexus3/pkg/security/role.go` — role CRUD operations
- `nexus3/pkg/security/user.go` — user CRUD operations  
- `nexus3/pkg/security/privilege/service.go` — privilege delete
- `nexus3/routing_rule.go` — routing rule CRUD operations
- `nexus3/mail_config.go` — mail config CRUD operations
- `nexus3/script.go` — script CRUD operations

This follows the pattern already established in `privilege/service.go` List and Get functions, which correctly include HTTP status codes.

## Related issues

- Fixes datadrivers/terraform-provider-nexus#555
- Related to datadrivers/terraform-provider-nexus#467
- Related to datadrivers/terraform-provider-nexus#318