### PR TITLE
feat: Add Alpine proxy repository support

### DIFF
--- a/nexus3/pkg/repository/alpine/service.go
+++ b/nexus3/pkg/repository/alpine/service.go
@@ -1,0 +1,29 @@
+package alpine
+
+import (
+	"github.com/datadrivers/go-nexus-client/nexus3/pkg/client"
+	"github.com/datadrivers/go-nexus-client/nexus3/pkg/repository/common"
+	"github.com/datadrivers/go-nexus-client/nexus3/schema/repository"
+)
+
+const alpineAPIEndpoint = common.RepositoryAPIEndpoint + "/alpine"
+
+type RepositoryAlpineProxyService = common.RepositoryService[repository.AlpineProxyRepository]
+
+type RepositoryAlpineService struct {
+	client *client.Client
+
+	Proxy *RepositoryAlpineProxyService
+}
+
+func NewRepositoryAlpineService(c *client.Client) *RepositoryAlpineService {
+	return &RepositoryAlpineService{
+		client: c,
+
+		Proxy: NewRepositoryAlpineProxyService(c),
+	}
+}
+
+func NewRepositoryAlpineProxyService(c *client.Client) *RepositoryAlpineProxyService {
+	return common.NewRepositoryService[repository.AlpineProxyRepository](alpineAPIEndpoint+"/proxy", c)
+}

--- a/nexus3/pkg/repository/service.go
+++ b/nexus3/pkg/repository/service.go
@@ -2,6 +2,7 @@ package repository
 
 import (
 	"github.com/datadrivers/go-nexus-client/nexus3/pkg/client"
+	"github.com/datadrivers/go-nexus-client/nexus3/pkg/repository/alpine"
 	"github.com/datadrivers/go-nexus-client/nexus3/pkg/repository/apt"
 	"github.com/datadrivers/go-nexus-client/nexus3/pkg/repository/bower"
 	"github.com/datadrivers/go-nexus-client/nexus3/pkg/repository/cargo"
@@ -30,52 +31,54 @@ type RepositoryService struct {
 	client *client.Client
 
 	// API Services
-	Apt       *apt.RepositoryAptService
-	Bower     *bower.RepositoryBowerService
-	Cargo     *cargo.RepositoryCargoService
-	Cocoapods *cocoapods.RepositoryCocoapodsService
-	Conan     *conan.RepositoryConanService
-	Conda     *conda.RepositoryCondaService
-	Docker    *docker.RepositoryDockerService
-	GitLfs    *gitlfs.RepositoryGitLfsService
-	Go        *golang.RepositoryGoService
-	Helm      *helm.RepositoryHelmService
+	Alpine      *alpine.RepositoryAlpineService
+	Apt         *apt.RepositoryAptService
+	Bower       *bower.RepositoryBowerService
+	Cargo       *cargo.RepositoryCargoService
+	Cocoapods   *cocoapods.RepositoryCocoapodsService
+	Conan       *conan.RepositoryConanService
+	Conda       *conda.RepositoryCondaService
+	Docker      *docker.RepositoryDockerService
+	GitLfs      *gitlfs.RepositoryGitLfsService
+	Go          *golang.RepositoryGoService
+	Helm        *helm.RepositoryHelmService
 	Huggingface *huggingface.RepositoryHuggingfaceService
-	Maven     *maven.RepositoryMavenService
-	Npm       *npm.RepositoryNpmService
-	Nuget     *nuget.RepositoryNugetService
-	P2        *p2.RepositoryP2Service
-	Pypi      *pypi.RepositoryPypiService
-	R         *r.RepositoryRService
-	Raw       *raw.RepositoryRawService
-	RubyGems  *rubygems.RepositoryRubyGemsService
-	Yum       *yum.RepositoryYumService
+	Maven       *maven.RepositoryMavenService
+	Npm         *npm.RepositoryNpmService
+	Nuget       *nuget.RepositoryNugetService
+	P2          *p2.RepositoryP2Service
+	Pypi        *pypi.RepositoryPypiService
+	R           *r.RepositoryRService
+	Raw         *raw.RepositoryRawService
+	RubyGems    *rubygems.RepositoryRubyGemsService
+	Yum         *yum.RepositoryYumService
 }
 
 func NewRepositoryService(c *client.Client) *RepositoryService {
 	return &RepositoryService{
 		client: c,
 
-		Apt:       apt.NewRepositoryAptService(c),
-		Bower:     bower.NewRepositoryBowerService(c),
-		Cargo:     cargo.NewRepositoryCargoService(c),
-		Cocoapods: cocoapods.NewRepositoryCocoapodsService(c),
-		Conan:     conan.NewRepositoryConanService(c),
-		Conda:     conda.NewRepositoryCondaService(c),
-		Docker:    docker.NewRepositoryDockerService(c),
-		GitLfs:    gitlfs.NewRepositoryGitLfsService(c),
-		Go:        golang.NewRepositoryGoService(c),
-		Helm:      helm.NewRepositoryHelmService(c),
+		Alpine:      alpine.NewRepositoryAlpineService(c),
+		Apt:         apt.NewRepositoryAptService(c),
+		Bower:       bower.NewRepositoryBowerService(c),
+		Cargo:       cargo.NewRepositoryCargoService(c),
+		Cocoapods:   cocoapods.NewRepositoryCocoapodsService(c),
+		Conan:       conan.NewRepositoryConanService(c),
+		Conda:       conda.NewRepositoryCondaService(c),
+		Docker:      docker.NewRepositoryDockerService(c),
+		GitLfs:      gitlfs.NewRepositoryGitLfsService(c),
+		Go:          golang.NewRepositoryGoService(c),
+		Helm:        helm.NewRepositoryHelmService(c),
 		Huggingface: huggingface.NewRepositoryHuggingfaceService(c),
-		Maven:     maven.NewRepositoryMavenService(c),
-		Npm:       npm.NewRepositoryNpmService(c),
-		Nuget:     nuget.NewRepositoryNugetService(c),
-		P2:        p2.NewRepositoryP2Service(c),
-		Pypi:      pypi.NewRepositoryPypiService(c),
-		R:         r.NewRepositoryRService(c),
-		Raw:       raw.NewRepositoryRawService(c),
-		RubyGems:  rubygems.NewRepositoryRubyGemsService(c),
-		Yum:       yum.NewRepositoryYumService(c),
+		Maven:       maven.NewRepositoryMavenService(c),
+		Npm:         npm.NewRepositoryNpmService(c),
+		Nuget:       nuget.NewRepositoryNugetService(c),
+		P2:          p2.NewRepositoryP2Service(c),
+		Pypi:        pypi.NewRepositoryPypiService(c),
+		R:           r.NewRepositoryRService(c),
+		Raw:         raw.NewRepositoryRawService(c),
+		RubyGems:    rubygems.NewRepositoryRubyGemsService(c),
+		Yum:         yum.NewRepositoryYumService(c),
 	}
 }
 

--- a/nexus3/schema/repository/alpine.go
+++ b/nexus3/schema/repository/alpine.go
@@ -1,0 +1,28 @@
+package repository
+
+type AlpineProxyRepository struct {
+	Name          string `json:"name"`
+	Online        bool   `json:"online"`
+	Storage       `json:"storage"`
+	Proxy         `json:"proxy"`
+	NegativeCache `json:"negativeCache"`
+	HTTPClient    `json:"httpClient"`
+	AlpineSigning `json:"alpineSigning,omitempty"`
+
+	// RoutingRule is used in POST Call and GET call returns RoutingRuleName. see issue: https://issues.sonatype.org/browse/NEXUS-30973
+
+	// The name of the routing rule assigned to this repository
+	RoutingRule *string `json:"routingRule,omitempty"`
+	// The name of the routing rule assigned to this repository
+	RoutingRuleName *string `json:"routingRuleName,omitempty"`
+
+	*Cleanup `json:"cleanup,omitempty"`
+}
+
+// AlpineSigning contains signing data for an Alpine repository
+type AlpineSigning struct {
+	// PEM-encoded RSA private key used to sign the APKINDEX
+	Keypair string `json:"keypair,omitempty"`
+	// Passphrase to access the signing key
+	Passphrase *string `json:"passphrase,omitempty"`
+}


### PR DESCRIPTION
Hi all! 

This PR adds support for the Alpine repository format (proxy type). Nexus recently added alpine support in their latest release. 

This adds:
- nexus3/schema/repository/alpine.go: AlpineProxyRepository and AlpineSigning schemas
- nexus3/pkg/repository/alpine/service.go: RepositoryAlpineService with Proxy sub-service
- nexus3/pkg/repository/service.go: Register Alpine in the top-level RepositoryService